### PR TITLE
fix #14 (ugly way)

### DIFF
--- a/src/gui/CMenuWindow.cpp
+++ b/src/gui/CMenuWindow.cpp
@@ -40,7 +40,7 @@ void CMenuWindow::AddElements() {
 	for (auto var : FindCatVars("aimbot_")) ADDCVAR(var);
 	AddTab("esp", "ESP");
 	tab = GetTab("esp");
-	for (auto var : FindCatVars("esp_")) ADDCVAR(var);
+	for (auto var : FindCatV#ars("esp_")) ADDCVAR(var);
 	AddTab("triggerbot", "Triggerbot");
 	tab = GetTab("triggerbot");
 	for (auto var : FindCatVars("triggerbot_")) ADDCVAR(var);
@@ -53,7 +53,7 @@ void CMenuWindow::AddElements() {
 	AddTab("misc", "Misc");
 	tab = GetTab("misc");
 	ADDCVARS("thirdperson");
-	ADDCVARS("log");
+	ADDCVARS("log"); // this also catches the logo cvar
 	ADDCVARS("no_");
 	ADDCVARS("fov");
 	ADDCVARS("clean_");
@@ -63,7 +63,6 @@ void CMenuWindow::AddElements() {
 	ADDCVARS("ignore_");
 	ADDCVARS("rollspeedhack");
 	ADDCVARS("minigun");
-	ADDCVARS("logo");
 	ADDCVARS("disconnect");
 
 	if (TF) ADDCVAR(&hacks::tf::autoheal::enabled);


### PR DESCRIPTION
This isn't the best looking way to fix it. In my opinion, having ADDCVARS take a string with wildcards as opposed to a string just to check for occurrences would definitely be better. However, the best method would be changing CatVar so that all categorization is done by the file initializing it. That would take a lot of rewriting, but if it were implemented correctly, could clean up the code considerably and make adding new hacks easier without reducing speed too much.