### PR TITLE
Use g++ if g++-6 doesn't exist (closes #29)

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-CXX=g++-6
+CXX=$(shell sh -c "which g++-6 || which g++")
 CXXFLAGS=-std=gnu++14 -D_GLIBCXX_USE_CXX11_ABI=0 -D_POSIX=1 -DRAD_TELEMETRY_DISABLED -DLINUX=1 -D_LINUX=1 -DPOSIX=1 -DGNUC=1 -D_DEVELOPER=1 -DNO_MALLOC_OVERRIDE -O3 -g3 -ggdb -w -shared -Wall -Wno-unknown-pragmas -fmessage-length=0 -m32 -fvisibility=hidden -fPIC
 SDKFOLDER=$(realpath source-sdk-2013/mp/src)
 SIMPLE_IPC_DIR = $(realpath simple-ipc/src/include)


### PR DESCRIPTION
dunno if we need to use sh -c for "||" but it works so who cares