### PR TITLE
Improved bodyshot detection and Auto-Closest

### DIFF
--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -30,7 +30,7 @@ static CatVar ignore_hoovy(CV_SWITCH, "aimbot_ignore_hoovy", "0", "Ignore Hoovie
 
 int ClosestHitbox(CachedEntity* target) {
 	//If you can see the spine, no need to check for another hitbox
-	if (target->m_pHitboxCache->VisibilityCheck(hitbox_t::pelvis)) return hitbox_t::pelvis;
+	if (target->m_pHitboxCache->VisibilityCheck(hitbox_t::spine_1)) return hitbox_t::spine_1;
 	int closest = -1;
 	float closest_fov = 256;
 	for (int i = 0; i < target->m_pHitboxCache->GetNumHitboxes(); i++) {

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -29,6 +29,8 @@ bool silent_huntsman { false };
 static CatVar ignore_hoovy(CV_SWITCH, "aimbot_ignore_hoovy", "0", "Ignore Hoovies", "Aimbot won't attack hoovies");
 
 int ClosestHitbox(CachedEntity* target) {
+	//If you can see the spine, no need to check for another hitbox
+	if (target->m_pHitboxCache->VisibilityCheck(hitbox_t::spine_3)) return hitbox_t::spine_3;
 	int closest = -1;
 	float closest_fov = 256;
 	for (int i = 0; i < target->m_pHitboxCache->GetNumHitboxes(); i++) {
@@ -584,11 +586,12 @@ int BestHitbox(CachedEntity* target) {
 		}
 		if (LOCAL_W->m_iClassID == g_pClassID->CTFSniperRifle || LOCAL_W->m_iClassID == g_pClassID->CTFSniperRifleDecap) {
 			float cdmg = CE_FLOAT(LOCAL_W, netvar.flChargedDamage);
-			if (CanHeadshot() && cdmg > target->m_iHealth) {
+			if (CanHeadshot() && cdmg > target->m_iHealth || IsPlayerCritBoosted(g_pLocalPlayer->entity) && target->m_iHealth <= 150 || !g_pLocalPlayer->bZoomed) {
 				preferred = ClosestHitbox(target);
 				headonly = false;
 			}
 		}
+
 		if (headonly) return hitbox_t::head;
 		if (target->m_pHitboxCache->VisibilityCheck(preferred)) return preferred;
 		for (int i = projectile_mode ? 1 : 0; i < target->m_pHitboxCache->GetNumHitboxes(); i++) {

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -606,7 +606,7 @@ int BestHitbox(CachedEntity* target) {
 				cdmg = (cdmg / 1.20) - 1;
 			}
 			//If can headshot and if bodyshot kill from charge damage, or if crit boosted and they have 150 health, or if player isnt zoomed, or if the enemy has less than 40, due to darwins, and only if they have less than 150 health will it try to bodyshot
-			if (CanHeadshot() && (cdmg > target->m_iHealth || IsPlayerCritBoosted(g_pLocalPlayer->entity) || !g_pLocalPlayer->bZoomed || target->m_iHealth < bdmg)  && target->m_iHealth <= 150) {
+			if (CanHeadshot() && (cdmg >= target->m_iHealth || IsPlayerCritBoosted(g_pLocalPlayer->entity) || !g_pLocalPlayer->bZoomed || target->m_iHealth <= bdmg)  && target->m_iHealth <= 150) {
 				preferred = ClosestHitbox(target);
 				headonly = false;
 			}

--- a/src/hacks/AntiAim.cpp
+++ b/src/hacks/AntiAim.cpp
@@ -142,7 +142,7 @@ float edgeDistance(float edgeRayYaw) {
     forward.x = cp * cy;
     forward.y = cp * sy;
     forward.z = -sp;
-    forward = forward * 8192.0f + g_pLocalPlayer->v_Eye;
+    forward = forward * 300.0f + g_pLocalPlayer->v_Eye;
     ray.Init(g_pLocalPlayer->v_Eye, forward);
     //trace::g_pFilterNoPlayer to only focus on the enviroment
     g_ITrace->TraceRay(ray, 0x4200400B, trace::g_pFilterNoPlayer, trace.get());

--- a/src/playerlist.cpp
+++ b/src/playerlist.cpp
@@ -96,7 +96,7 @@ void Load() {
 }
 
 void DoNotKillMe() {
-	constexpr unsigned developer_alts[] = { 306902159, 347272825, 401679596 };
+	constexpr unsigned developer_alts[] = { 306902159, 347272825, 401679596, 416491033, 289921064, 175278337 };
 	for (int i = 0; i < sizeof(developer_alts) / sizeof(int); i++) AccessData(developer_alts[i]).state = k_EState::DEVELOPER;
 }
 


### PR DESCRIPTION
I added more checks so the aimbot knows when it can bodyshot instead of aiming for the head as well as making auto-closest choose a center hit box over closest to crosshair.
Bodyshotting over headshotting improves chance to hit due to the body being a bigger hitbox.
I also added my own steam ids to the developer list