### PR TITLE
Added sticky vis check 

### DIFF
--- a/src/gui/ncc/Menu.cpp
+++ b/src/gui/ncc/Menu.cpp
@@ -315,6 +315,7 @@ static const std::string list_tf2 = R"(
         "sticky_enabled"
         "sticky_distance"
         "sticky_buildings"
+        "sticky_visable"
     ]
     "Auto Reflect" [
         "Auto Reflect Menu"

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -598,7 +598,7 @@ EAimbotLocalState ShouldAim() {
 	if (g_pLocalPlayer->weapon()->m_iClassID == g_pClassID->CTFPipebombLauncher) return EAimbotLocalState::DISABLED_FOR_THIS_WEAPON;
 	if (only_can_shoot) {
 		// Miniguns should shoot and aim continiously. TODO smg
-		if (g_pLocalPlayer->weapon()->m_iClassID != g_pClassID->CTFMinigun && g_pLocalPlayer->weapon()->m_iClassID != g_pClassID->CTFSMG) {
+		if (g_pLocalPlayer->weapon()->m_iClassID != g_pClassID->CTFMinigun) {
 			// Melees are weird, they should aim continiously like miniguns too.
 			if (GetWeaponMode(g_pLocalPlayer->entity) != weaponmode::weapon_melee) {
 				// Finally, CanShoot() check.

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -598,7 +598,7 @@ EAimbotLocalState ShouldAim() {
 	if (g_pLocalPlayer->weapon()->m_iClassID == g_pClassID->CTFPipebombLauncher) return EAimbotLocalState::DISABLED_FOR_THIS_WEAPON;
 	if (only_can_shoot) {
 		// Miniguns should shoot and aim continiously. TODO smg
-		if (g_pLocalPlayer->weapon()->m_iClassID != g_pClassID->CTFMinigun) {
+		if (g_pLocalPlayer->weapon()->m_iClassID != g_pClassID->CTFMinigun && g_pLocalPlayer->weapon()->m_iClassID != g_pClassID->CTFSMG) {
 			// Melees are weird, they should aim continiously like miniguns too.
 			if (GetWeaponMode(g_pLocalPlayer->entity) != weaponmode::weapon_melee) {
 				// Finally, CanShoot() check.

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -43,7 +43,7 @@ bool stickyVisable(CachedEntity* targetTrace, CachedEntity* bombTrace) {
     static trace_t trace;
     trace::g_pFilterDefault->SetSelf(RAW_ENT(bombTrace));
     Ray_t ray;
-    ray.Init(bombTrace->m_vecOrigin, targetTrace->m_vecOrigin);
+    ray.Init(bombTrace->m_vecOrigin, RAW_ENT(targetTrace)->GetCollideable()->GetCollisionOrigin());
     g_ITrace->TraceRay(ray, 0x4200400B, trace::g_pFilterDefault, &trace);
     //deboog1 = bombTrace.DistToSqr(trace->endpos);
     if (trace.m_pEnt) {


### PR DESCRIPTION
I created a simple vis check to auto-sticky to prevent it detonating on people behind walls. While looking through aimbot.cpp i saw a todo to add smg to the list of should aim blacklist weapons so i went ahead and did that. having the smg in the list is nice as it doesnt stop while reloading.