### PR TITLE
Add auto-detection to ./attach-pid

### DIFF
--- a/attach-pid
+++ b/attach-pid
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-proc=$1
-
-echo Attaching to "$proc"
+proc=${1:-$(ps $(pidof gameoverlayui) | tail -n1 | cut -d\- -f2 | cut -d\  -f2)}
+if ! [[ $proc =~ ^[0-9]+$ ]]; then
+   echo "Couldn't find process! Are you sure a game is running?" >&2; exit 1
+fi
 
 if grep -q "$(realpath bin/libcathook.so)" /proc/"$proc"/maps; then
   echo already loaded


### PR DESCRIPTION
Now if you do not provide a PID, it will automagically find whatever game Steam is running.
Nobody except for maybe 2 people are going to use this, but I thought it was nice.