### PR TITLE
Remove redundant installation + fix accidental update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo apt update && sudo apt install build-essential software-properties-common -
 
 Arch dependencies installation::
 ```bash
-sudo pacman -Syu && && sudo pacman -S base-devel gdb gdb-common glew1.10 lib32-glew1.10  && sudo pacman -U https://archive.archlinux.org/packages/g/gcc-multilib/gcc-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/g/gcc-libs-multilib/gcc-libs-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/l/lib32-gcc-libs/lib32-gcc-libs-6.3.1-2-x86_64.pkg.tar.xz
+sudo pacman -Syu && sudo pacman -S base-devel gdb gdb-common glew1.10 lib32-glew1.10 && sudo pacman -U https://archive.archlinux.org/packages/g/gcc-multilib/gcc-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/g/gcc-libs-multilib/gcc-libs-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/l/lib32-gcc-libs/lib32-gcc-libs-6.3.1-2-x86_64.pkg.tar.xz
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo apt update && sudo apt install build-essential software-properties-common -
 
 Arch dependencies installation::
 ```bash
-sudo pacman -Syu && sudo pacman -U https://archive.archlinux.org/packages/g/gcc-multilib/gcc-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/g/gcc-libs-multilib/gcc-libs-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/l/lib32-gcc-libs/lib32-gcc-libs-6.3.1-2-x86_64.pkg.tar.xz && sudo pacman -S base-devel gcc-multilib gdb gdb-common glew1.10 lib32-glew1.10 
+sudo pacman -Syu && && sudo pacman -S base-devel gdb gdb-common glew1.10 lib32-glew1.10  && sudo pacman -U https://archive.archlinux.org/packages/g/gcc-multilib/gcc-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/g/gcc-libs-multilib/gcc-libs-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/l/lib32-gcc-libs/lib32-gcc-libs-6.3.1-2-x86_64.pkg.tar.xz
 ```
 
 


### PR DESCRIPTION
Before: gcc6 is installed, then script updates to gcc7.

Now: other dependencies are installed first, then gcc6 downgrade. In no way should the script install gcc7 now.