### PR TITLE
Removed redundancies & user interaction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo apt update && sudo apt install build-essential software-properties-common -
 
 Arch dependencies installation::
 ```bash
-sudo pacman -Syu && sudo pacman -S base-devel gdb gdb-common glew1.10 lib32-glew1.10 && sudo pacman -U https://archive.archlinux.org/packages/g/gcc-multilib/gcc-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/g/gcc-libs-multilib/gcc-libs-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/l/lib32-gcc-libs/lib32-gcc-libs-6.3.1-2-x86_64.pkg.tar.xz
+sudo pacman -Syu && sudo pacman -S gdb gdb-common glew1.10 lib32-glew1.10 --noconfirm && yes | sudo pacman -U https://archive.archlinux.org/packages/g/gcc-multilib/gcc-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/g/gcc-libs-multilib/gcc-libs-multilib-6.3.1-2-x86_64.pkg.tar.xz https://archive.archlinux.org/packages/l/lib32-gcc-libs/lib32-gcc-libs-6.3.1-2-x86_64.pkg.tar.xz
 ```
 
 


### PR DESCRIPTION
The current installation script requires 3 user interactions:

1. Password for sudo
2. base-devel "select packages"
3. gcc in conflict with gcc-mutilibs.

Fix for 1 could be to use yaourt instead. 
Fix for 2 would be to manually install the packages inside the group - but which ones are quired for cathook compilation?
Fix for 3 is to use --noconfirm.


On second thought, would base-devel even be required? It's basically the first thing ever installed on arch machines. And the conflic with gcc and gcc-multilibs is because base-devel installs gcc.
Removing base-devel would fix 2.

After testing the script, using --noconfirm to fix 3 auto-no's. But, using "yes | " before the script auto-yes's. 


tl;dr Removed base-devel from installation, since it's more than likely already installed. Auto-confirm for gcc-multilib in case in conflict with gcc. 