### PR TITLE
bash: update-menu: No such file or directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo pacman -Syu && sudo pacman -S gdb gdb-common glew1.10 lib32-glew1.10 --noco
 
 Cathook installation script:
 ```bash
-git clone --recursive https://github.com/nullifiedcat/cathook && cd cathook && make -j4 && bash update-menu
+git clone --recursive https://github.com/nullifiedcat/cathook && cd cathook && make -j4 && bash update-data
 ```
 
 **Errors while installing?**


### PR DESCRIPTION
Edit: Proper title would be "Cathook installation script running update-menu (removed) instead of update-data

```
Building cathook
make[1]: Leaving directory '/home/depre/cathook'
bash: update-menu: No such file or directory
```

update-menu was renamed to update-data recently.