### PR TITLE
Strings must use doublequote. (quotes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d208d05091854caaa51d2757d2097b2c)](https://www.codacy.com/app/SylveonBottle/cathook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=SylveonBottle/cathook&amp;utm_campaign=Badge_Grade)
 # Cathook Multihack
 ![banner](https://raw.githubusercontent.com/nullifiedcat/cathook/master/banner.png)
 

--- a/README.md
+++ b/README.md
@@ -75,5 +75,3 @@ The installation script is as followed:
 git clone --recursive https://github.com/nullifiedcat/cathook-ipc-server && cd cathook-ipc-server && make -j4
 ```
 To run the Followbot server, run `./bin/cathook-ipc-server`. You can also use `./bin/cathook-ipc-server &>/dev/null &` to run it in background.
-
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d208d05091854caaa51d2757d2097b2c)](https://www.codacy.com/app/SylveonBottle/cathook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=SylveonBottle/cathook&amp;utm_campaign=Badge_Grade)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d208d05091854caaa51d2757d2097b2c)](https://www.codacy.com/app/SylveonBottle/cathook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=SylveonBottle/cathook&amp;utm_campaign=Badge_Grade)
 # Cathook Multihack
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d208d05091854caaa51d2757d2097b2c)](https://www.codacy.com/app/SylveonBottle/cathook?utm_source=github.com&utm_medium=referral&utm_content=SylveonBottle/cathook&utm_campaign=badger)
-
 ![banner](https://raw.githubusercontent.com/nullifiedcat/cathook/master/banner.png)
 
 cathook is a multihack for Team Fortress 2 for Linux. cathook includes some joke features like

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Cathook Multihack
-
 ![banner](https://raw.githubusercontent.com/nullifiedcat/cathook/master/banner.png)
 
 cathook is a multihack for Team Fortress 2 for Linux. cathook includes some joke features like

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d208d05091854caaa51d2757d2097b2c)](https://www.codacy.com/app/SylveonBottle/cathook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=SylveonBottle/cathook&amp;utm_campaign=Badge_Grade)
 # Cathook Multihack
 
 ![banner](https://raw.githubusercontent.com/nullifiedcat/cathook/master/banner.png)
@@ -76,3 +75,5 @@ The installation script is as followed:
 git clone --recursive https://github.com/nullifiedcat/cathook-ipc-server && cd cathook-ipc-server && make -j4
 ```
 To run the Followbot server, run `./bin/cathook-ipc-server`. You can also use `./bin/cathook-ipc-server &>/dev/null &` to run it in background.
+
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d208d05091854caaa51d2757d2097b2c)](https://www.codacy.com/app/SylveonBottle/cathook?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=SylveonBottle/cathook&amp;utm_campaign=Badge_Grade)

--- a/generate-class-headers.js
+++ b/generate-class-headers.js
@@ -52,7 +52,7 @@ namespace client_classes {
 for (var clz in full_class_table) {
 	var value = "0";
 	if (classes[clz]) value = classes[clz];
-	header_constexpr += '\t\tstatic constexpr int ' + clz + ' = ' + value + ';\n';
+	header_constexpr += "\t\tstatic constexpr int " + clz + " = " + value + ";\n";
 	header += "\t\tint " + clz + " { " + value + " };\n";
 }
 

--- a/generate-class-headers.js
+++ b/generate-class-headers.js
@@ -1,14 +1,14 @@
-const fs = require('fs');
+const fs = require("fs");
 
 var full_class_table = {};
 try {
-	full_class_table = JSON.parse(fs.readFileSync('full-class-table.json').toString());
+	full_class_table = JSON.parse(fs.readFileSync("full-class-table.json").toString());
 } catch (e) {}
 
-const file = fs.readFileSync(process.argv[2]).toString().split('\n');
+const file = fs.readFileSync(process.argv[2]).toString().split("\n");
 const modname = process.argv[3];
 
-console.log('Generating info for', modname, 'from', process.argv[2]);
+console.log("Generating info for", modname, "from", process.argv[2]);
 
 var classes = {};
 for (var i in file) {
@@ -19,7 +19,7 @@ for (var i in file) {
 	}
 }
 
-fs.writeFileSync('full-class-table.json', JSON.stringify(full_class_table));
+fs.writeFileSync("full-class-table.json", JSON.stringify(full_class_table));
 
 var header_constexpr = `/*
 	AUTO-GENERATED HEADER - DO NOT MODIFY
@@ -50,10 +50,10 @@ namespace client_classes {
 `;
 
 for (var clz in full_class_table) {
-	var value = '0';
+	var value = "0";
 	if (classes[clz]) value = classes[clz];
 	header_constexpr += '\t\tstatic constexpr int ' + clz + ' = ' + value + ';\n';
-	header += '\t\tint ' + clz + ' { ' + value + ' };\n';
+	header += "\t\tint " + clz + " { " + value + " };\n";
 }
 
 header += `
@@ -70,8 +70,8 @@ header_constexpr += `
 
 #endif /* $mod_CONSTEXPR_AUTOGEN_HPP */`;
 
-fs.writeFileSync('src/classinfo/' + modname + '.gen.hpp', header.replace(/\$mod/g, modname));
-fs.writeFileSync('src/classinfo/' + modname + '_constexpr.gen.hpp', header_constexpr.replace(/\$mod/g, modname));
+fs.writeFileSync("src/classinfo/" + modname + ".gen.hpp", header.replace(/\$mod/g, modname));
+fs.writeFileSync("src/classinfo/" + modname + "_constexpr.gen.hpp", header_constexpr.replace(/\$mod/g, modname));
 
 
 console.log(classes);

--- a/generate-dummy-header.js
+++ b/generate-dummy-header.js
@@ -5,7 +5,7 @@ try {
 	full_class_table = JSON.parse(fs.readFileSync("full-class-table.json").toString());
 } catch (e) {}
 
-console.log('Generating dummy class header');
+console.log("Generating dummy class header");
 
 var header = `/*
 	AUTO-GENERATED HEADER - DO NOT MODIFY

--- a/generate-dummy-header.js
+++ b/generate-dummy-header.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
+const fs = require("fs");
 
 var full_class_table = {};
 try {
-	full_class_table = JSON.parse(fs.readFileSync('full-class-table.json').toString());
+	full_class_table = JSON.parse(fs.readFileSync("full-class-table.json").toString());
 } catch (e) {}
 
 console.log('Generating dummy class header');
@@ -22,7 +22,7 @@ namespace client_classes {
 `;
 
 for (var clz in full_class_table) {
-	header += '\t\tint ' + clz + ' { 0 };\n';
+	header += "\t\tint " + clz + " { 0 };\n";
 }
 
 header += `
@@ -33,4 +33,4 @@ header += `
 
 #endif /* DUMMY_AUTOGEN_HPP */`;
 
-fs.writeFileSync('src/classinfo/dummy.gen.hpp', header);
+fs.writeFileSync("src/classinfo/dummy.gen.hpp", header);

--- a/generate-dynamic-header.js
+++ b/generate-dynamic-header.js
@@ -1,11 +1,11 @@
-const fs = require('fs');
+const fs = require("fs");
 
 var full_class_table = {};
 try {
-	full_class_table = JSON.parse(fs.readFileSync('full-class-table.json').toString());
+	full_class_table = JSON.parse(fs.readFileSync("full-class-table.json").toString());
 } catch (e) {}
 
-console.log('Generating dummy class header');
+console.log("Generating dummy class header");
 
 var header = `/*
 	AUTO-GENERATED HEADER - DO NOT MODIFY
@@ -24,7 +24,7 @@ namespace client_classes {
 `;
 
 for (var clz in full_class_table) {
-	header += '\t\tint ' + clz + ' { 0 };\n';
+	header += "\t\tint " + clz + " { 0 };\n";
 }
 
 header += `
@@ -35,7 +35,7 @@ header += `
 
 #endif /* DYNAMIC_AUTOGEN_HPP */`;
 
-var POPULATED_MAP = '';
+var POPULATED_MAP = "";
 
 for (var clz in full_class_table) {
 	POPULATED_MAP += `\t\tclassid_mapping["${clz}"] = &${clz};\n`;
@@ -69,5 +69,5 @@ dynamic dynamic_list;
 }`;
 
 
-fs.writeFileSync('src/classinfo/dynamic.gen.hpp', header);
-fs.writeFileSync('src/classinfo/dynamic.gen.cpp', source);
+fs.writeFileSync("src/classinfo/dynamic.gen.hpp", header);
+fs.writeFileSync("src/classinfo/dynamic.gen.cpp", source);


### PR DESCRIPTION
### [Codacy](https://www.codacy.com/app/SylveonBottle/cathook/commit?cid=115189164) detected an issue:
#### Message: `Strings must use doublequote. (quotes)`

### Why is this an issue?
JavaScript allows you to define strings in one of three ways: double quotes, single quotes, and backticks (as of ECMAScript 6). Each of these lines creates a string and, in some cases, can be used interchangeably. The choice of how to define strings in a codebase is a stylistic one outside of template literals (which allow embedded of expressions to be interpreted). Many codebases require strings to be defined in a consistent manner. This rule takes as parameter the style you prefer ("double", "single" or "backtick") default is double.
```
//Bad with double:
var single = 'single';
var unescaped = 'a string containing "double" quotes';
```

Also I was gonna add codacy button but decided against it, then realised I have no idea how to un-commit shit so I just made more commits fixing it or something idk