### PR TITLE
Fixed 100% Rare Medal Flip

### DIFF
--- a/include/copypasted/CSignature.h
+++ b/include/copypasted/CSignature.h
@@ -13,6 +13,7 @@ public:
     void *GetModuleHandleSafe(const char *pszModuleName);
     uintptr_t GetClientSignature(char *chPattern);
     uintptr_t GetEngineSignature(char *chPattern);
+    uintptr_t GetVstdSignature(char *chPattern);
 };
 
 extern CSignature gSignatures;

--- a/include/hooks.hpp
+++ b/include/hooks.hpp
@@ -64,6 +64,7 @@ extern VMTHook baseclientstate8;
 extern VMTHook steamfriends;
 extern VMTHook materialsystem;
 extern VMTHook enginevgui;
+extern VMTHook vstd;
 }
 
 #endif /* HOOKS_H_ */

--- a/include/hooks/hookedmethods.hpp
+++ b/include/hooks/hookedmethods.hpp
@@ -31,6 +31,8 @@ typedef bool (*ProcessSetConVar_t)(CBaseClientState *, NET_SetConVar *);
 typedef bool (*ProcessGetCvarValue_t)(CBaseClientState *, SVC_GetCvarValue *);
 typedef void (*Paint_t)(IEngineVGui *, PaintMode_t);
 
+typedef int (*RandomInt_t)(void*, int, int);
+
 const char *GetClientName_hook(CBaseClientState *_this);
 bool ProcessSetConVar_hook(CBaseClientState *_this, NET_SetConVar *msg);
 bool ProcessGetCvarValue_hook(CBaseClientState *_this, SVC_GetCvarValue *msg);

--- a/include/hooks/others.hpp
+++ b/include/hooks/others.hpp
@@ -26,6 +26,7 @@ bool DispatchUserMessage_hook(void *, int, bf_read &);
 void FrameStageNotify_hook(void *, int);
 void LevelInit_hook(void *, const char *);
 void LevelShutdown_hook(void *);
+int RandomInt_hook(void*, int, int);
 
 #if ENABLE_NULL_GRAPHICS == 1
 typedef ITexture *(*FindTexture_t)(void *, const char *, const char *, bool,

--- a/include/interfaces.hpp
+++ b/include/interfaces.hpp
@@ -85,6 +85,7 @@ extern CBaseClientState *g_IBaseClientState;
 extern IGameEventManager *g_IGameEventManager;
 extern CGameRules *g_pGameRules;
 extern IEngineVGui *g_IEngineVGui;
+extern IUniformRandomStream *g_pUniformStream;
 
 void CreateInterfaces();
 

--- a/include/offsets.hpp
+++ b/include/offsets.hpp
@@ -161,6 +161,10 @@ struct offsets
     {
         return PlatformOffset(196, undefined, undefined);
     }
+    static constexpr uint32_t RandomInt()
+    {
+        return PlatformOffset(2, undefined, undefined);
+    }
 };
 
 #endif /* OFFSETS_HPP_ */

--- a/src/copypasted/CSignature.cpp
+++ b/src/copypasted/CSignature.cpp
@@ -147,5 +147,32 @@ uintptr_t CSignature::GetEngineSignature(char *chPattern)
                          chPattern) -
            (uintptr_t)(module) + moduleMap->l_addr;
 }
+//===================================================================================
+uintptr_t CSignature::GetVstdSignature(char *chPattern)
+{
+    // we need to do this becuase (i assume that) under the hood, dlopen only
+    // loads up the sections that it needs into memory, meaning that we cannot
+    // get the string table from the module.
+    static int fd = open(sharedobj::vstdlib().path.c_str(), O_RDONLY);
+    static void *module =
+        mmap(NULL, lseek(fd, 0, SEEK_END), PROT_READ, MAP_SHARED, fd, 0);
+    static link_map *moduleMap = sharedobj::vstdlib().lmap;
+
+    // static void *module = (void *)moduleMap->l_addr;
+
+    static Elf32_Shdr *textHeader = getSectionHeader(module, ".text");
+
+    static int textOffset = textHeader->sh_offset;
+
+    static int textSize = textHeader->sh_size;
+
+    // we need to remap the address that we got from the pattern search from our
+    // mapped file to the actual memory we do this by rebasing the address
+    // (subbing the mmapped one and adding the dlopened one.
+    return dwFindPattern(((uintptr_t) module) + textOffset,
+                         ((uintptr_t) module) + textOffset + textSize,
+                         chPattern) -
+           (uintptr_t)(module) + moduleMap->l_addr;
+}
 
 CSignature gSignatures;

--- a/src/hack.cpp
+++ b/src/hack.cpp
@@ -203,31 +203,6 @@ void hack::Initialize()
     logging::Info("Is TF? %d", IsTF());
     InitClassTable();
 
-#if ENABLE_VISUALS ==                                                          \
-    1 /* We don't need medal to flip 100% when running textmode */
-
-    IF_GAME(IsTF2())
-    {
-        /*
-    uintptr_t mmmf = (gSignatures.GetClientSignature("C7 44 24 04 09 00 00 00 BB
-    ? ? ? ? C7 04 24 00 00 00 00 E8 ? ? ? ? BA ? ? ? ? 85 C0 B8 ? ? ? ? 0F 44
-    DA") + 37); if (mmmf) { unsigned char patch1[] = { 0x89, 0xD3, 0x90 };
-        unsigned char patch2[] = { 0x89, 0xC2, 0x90 };
-        Patch((void*)mmmf, (void*)patch1, 3);
-        Patch((void*)(mmmf + 8), (void*)patch2, 3);
-    }*/
-        /*uintptr_t canInspectSig = (gSignatures.GetClientSignature("55 0F 57 C0
-        89 E5 83 EC 48 8B 45 08 F3 0F 11 04 24 F3 0F 11 45 E8 C7 44 24 10 01 00
-        00 00 C7 44 24 0C 00 00 00 00 89 44 24 08 C7 44 24 ? ? ? ? ? E8 ? ? ? ?
-        F3 0F 10 45 E8 D9 5D E4 F3 0F 10 4D E4 C9 0F 2F C8 0F 95 C0 C3") + 72);
-        if (canInspectSig) {
-            unsigned char patch[] = { 0xB0, 0x01, 0x90 };
-            Patch((void*)canInspectSig, (void*)patch, 3);
-        }*/
-    }
-
-#endif /* TEXTMODE */
-
     BeginConVars();
     hack::c_Cat = CreateConCommand(CON_NAME, &hack::CC_Cat, "Info");
     g_Settings.Init();
@@ -287,6 +262,12 @@ g_pGUI->Setup();
 #endif
     hooks::client.HookMethod((void *) DispatchUserMessage_hook,
                              offsets::DispatchUserMessage());
+
+#if ENABLE_VISUALS == 1
+    hooks::vstd.Set((void *)g_pUniformStream);
+    hooks::vstd.HookMethod((void *)RandomInt_hook, offsets::RandomInt());
+    hooks::vstd.Apply();
+#endif
 
 #if ENABLE_NULL_GRAPHICS == 1
     g_IMaterialSystem->SetInStubMode(true);

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -104,4 +104,5 @@ VMTHook modelrender{};
 VMTHook clientmode4{};
 VMTHook materialsystem{};
 VMTHook enginevgui{};
+VMTHook vstd{};
 }

--- a/src/hooks/others.cpp
+++ b/src/hooks/others.cpp
@@ -17,6 +17,7 @@
 
 static CatVar no_invisibility(CV_SWITCH, "no_invis", "0", "Remove Invisibility",
                               "Useful with chams!");
+static CatVar medal_flip(CV_SWITCH, "medal_flip", "0", "Infinite Medal Flip", "");
 
 // This hook isn't used yet!
 int C_TFPlayer__DrawModel_hook(IClientEntity *_this, int flags)
@@ -928,4 +929,14 @@ void LevelShutdown_hook(void *_this)
             .ts_disconnected = time(nullptr);
     }
 #endif
+}
+
+int RandomInt_hook(void *_this, int iMinVal, int iMaxVal)
+{
+    static const RandomInt_t original = 
+        RandomInt_t(hooks::vstd.GetMethod(offsets::RandomInt()));
+    
+    if (medal_flip && iMinVal == 0 && iMaxVal == 9) return 0;
+
+    return original(_this, iMinVal, iMaxVal);
 }

--- a/src/interfaces.cpp
+++ b/src/interfaces.cpp
@@ -49,6 +49,7 @@ TFGCClientSystem *g_TFGCClientSystem    = nullptr;
 CHud *g_CHUD                            = nullptr;
 CGameRules *g_pGameRules                = nullptr;
 IEngineVGui *g_IEngineVGui				= nullptr;
+IUniformRandomStream *g_pUniformStream  = nullptr;
 
 template <typename T>
 T *BruteforceInterface(std::string name, sharedobj::SharedObject &object,
@@ -197,6 +198,10 @@ void CreateInterfaces()
         "VMaterialSystem", sharedobj::materialsystem());
 
 #if ENABLE_VISUALS == 1
+    uintptr_t addy = gSignatures.GetVstdSignature("A3 ? ? ? ? C3 89 F6") + 0x1;
+    logging::Info("g_pUniformStream: 0x%08x", addy);
+    logging::Info("*g_pUniformStream: 0x%08x", *(IUniformRandomStream**)addy);
+    g_pUniformStream = **(IUniformRandomStream***)(addy);    
     g_IVDebugOverlay = BruteforceInterface<IVDebugOverlay>("VDebugOverlay",
                                                            sharedobj::engine());
     g_IPanel =

--- a/src/interfaces.cpp
+++ b/src/interfaces.cpp
@@ -198,10 +198,7 @@ void CreateInterfaces()
         "VMaterialSystem", sharedobj::materialsystem());
 
 #if ENABLE_VISUALS == 1
-    uintptr_t addy = gSignatures.GetVstdSignature("A3 ? ? ? ? C3 89 F6") + 0x1;
-    logging::Info("g_pUniformStream: 0x%08x", addy);
-    logging::Info("*g_pUniformStream: 0x%08x", *(IUniformRandomStream**)addy);
-    g_pUniformStream = **(IUniformRandomStream***)(addy);    
+    g_pUniformStream = **(IUniformRandomStream***)(gSignatures.GetVstdSignature("A3 ? ? ? ? C3 89 F6") + 0x1);    
     g_IVDebugOverlay = BruteforceInterface<IVDebugOverlay>("VDebugOverlay",
                                                            sharedobj::engine());
     g_IPanel =


### PR DESCRIPTION
- Fixed 100% rare medal flip by replacing the unused byte patch with a hook.

- Added CatVar `cat_medal_flip`

- Added pattern scanning for `libvstdlib.so`